### PR TITLE
docs: prefer `test` rather than `t`

### DIFF
--- a/__tests__/01.basic-transactions.ava.ts
+++ b/__tests__/01.basic-transactions.ava.ts
@@ -17,30 +17,30 @@ const runner = Runner.create(async ({root}) => ({
   ali: await root.createAccount('ali'),
 }));
 
-runner.test('Root gets null status', async (t, {contract, root}) => {
+runner.test('Root gets null status', async (test, {contract, root}) => {
   const result = await contract.view('get_status', {
     account_id: root,
   });
-  t.is(result, null);
+  test.is(result, null);
 });
 
-runner.test('Ali sets then gets status', async (t, {contract, ali}) => {
+runner.test('Ali sets then gets status', async (test, {contract, ali}) => {
   await ali.call(contract, 'set_status', {message: 'hello'});
   const result: string = await contract.view('get_status', {
     account_id: ali,
   });
-  t.is(result, 'hello');
+  test.is(result, 'hello');
 });
 
-runner.test('Root and Ali have different statuses', async (t, {contract, root, ali}) => {
+runner.test('Root and Ali have different statuses', async (test, {contract, root, ali}) => {
   await root.call(contract, 'set_status', {message: 'world'});
   const rootStatus: string = await contract.view('get_status', {
     account_id: root,
   });
-  t.is(rootStatus, 'world');
+  test.is(rootStatus, 'world');
 
   const aliStatus = await contract.view('get_status', {
     account_id: ali,
   });
-  t.is(aliStatus, null);
+  test.is(aliStatus, null);
 });

--- a/__tests__/02.patch-state.ava.ts
+++ b/__tests__/02.patch-state.ava.ts
@@ -53,7 +53,7 @@ if (Runner.networkIsSandbox()) {
     ],
   ]);
 
-  runner.test('View state', async (t, {contract, ali}) => {
+  runner.test('View state', async (test, {contract, ali}) => {
     await ali.call(contract, 'set_status', {message: 'hello'});
 
     const state = await contract.viewState();
@@ -68,12 +68,12 @@ if (Runner.networkIsSandbox()) {
       data,
     );
 
-    t.deepEqual(statusMessage.records[0],
+    test.deepEqual(statusMessage.records[0],
       new Record({k: ali.accountId, v: 'hello'}),
     );
   });
 
-  runner.test('Patch state', async (t, {contract, ali}) => {
+  runner.test('Patch state', async (test, {contract, ali}) => {
     // Contract must have some state for viewState & patchState to work
     await ali.call(contract, 'set_status', {message: 'hello'});
     // Get state
@@ -96,10 +96,10 @@ if (Runner.networkIsSandbox()) {
     const result = await contract.view('get_status', {
       account_id: 'alice.near',
     });
-    t.is(result, 'hello world');
+    test.is(result, 'hello world');
   });
 
-  runner.test('Patch Account', async (t, {root, ali, contract}) => {
+  runner.test('Patch Account', async (test, {root, ali, contract}) => {
     const bob = root.getFullAccount('bob');
     const public_key = await bob.setKey();
     const {code_hash} = await contract.accountView();
@@ -119,11 +119,11 @@ if (Runner.networkIsSandbox()) {
     await bob.updateContract(await contract.viewCode());
 
     const balance = await bob.availableBalance();
-    t.deepEqual(balance, BOB_BALANCE);
+    test.deepEqual(balance, BOB_BALANCE);
     await ali.call(bob, 'set_status', {message: 'hello'});
     const result = await bob.view('get_status', {
       account_id: ali.accountId,
     });
-    t.is(result, 'hello');
+    test.is(result, 'hello');
   });
 }

--- a/__tests__/03.single-use-access-keys-with-linkdrop.ava.ts
+++ b/__tests__/03.single-use-access-keys-with-linkdrop.ava.ts
@@ -33,7 +33,7 @@ const runner = Runner.create(async ({root}) => ({
   ),
 }));
 
-runner.test('Use `create_account_and_claim` to create a new account', async (t, {root, linkdrop}) => {
+runner.test('Use `create_account_and_claim` to create a new account', async (test, {root, linkdrop}) => {
   // Create temporary keys for access key on linkdrop
   const senderKey = createKeyPair();
   const public_key = senderKey.getPublicKey().toString();
@@ -60,15 +60,15 @@ runner.test('Use `create_account_and_claim` to create a new account', async (t, 
   );
   const bob = root.getAccount(new_account_id);
   const balance = await bob.availableBalance();
-  t.log(balance.toHuman());
-  t.deepEqual(balance, NEAR.parse('0.99818'));
+  test.log(balance.toHuman());
+  test.deepEqual(balance, NEAR.parse('0.99818'));
 
-  t.log(
+  test.log(
     `Account ${new_account_id} claim and has ${balance.toHuman()} available`,
   );
 });
 
-runner.test('Use `claim` to transfer to an existing account', async (t, {root, linkdrop}) => {
+runner.test('Use `claim` to transfer to an existing account', async (test, {root, linkdrop}) => {
   const bob = await root.createAccount('bob');
   const originalBalance = await bob.availableBalance();
   // Create temporary keys for access key on linkdrop
@@ -93,9 +93,9 @@ runner.test('Use `claim` to transfer to an existing account', async (t, {root, l
   );
 
   const newBalance = await bob.availableBalance();
-  t.assert(originalBalance.lt(newBalance));
+  test.assert(originalBalance.lt(newBalance));
 
-  t.log(
+  test.log(
     `${bob.accountId} claimed ${newBalance
       .sub(originalBalance).toHuman()}`,
   );

--- a/__tests__/04.cross-contract-calls-with-fungible-token.ava.ts
+++ b/__tests__/04.cross-contract-calls-with-fungible-token.ava.ts
@@ -56,14 +56,14 @@ const runner = Runner.create(async ({root}) => ({
   ali: await root.createAccount('ali'),
 }));
 
-runner.test('Total supply', async (t, {ft, ali}) => {
+runner.test('Total supply', async (test, {ft, ali}) => {
   await init_ft(ft, ali, '1000');
 
   const totalSupply: string = await ft.view('ft_total_supply');
-  t.is(totalSupply, '1000');
+  test.is(totalSupply, '1000');
 });
 
-runner.test('Simple transfer', async (t, {ft, ali, root}) => {
+runner.test('Simple transfer', async (test, {ft, ali, root}) => {
   const initialAmount = new BN('10000');
   const transferAmount = new BN('100');
   await init_ft(ft, root, initialAmount);
@@ -87,11 +87,11 @@ runner.test('Simple transfer', async (t, {ft, ali, root}) => {
   const aliBalance: string = await ft.view('ft_balance_of', {
     account_id: ali,
   });
-  t.deepEqual(new BN(rootBalance), initialAmount.sub(transferAmount));
-  t.deepEqual(new BN(aliBalance), transferAmount);
+  test.deepEqual(new BN(rootBalance), initialAmount.sub(transferAmount));
+  test.deepEqual(new BN(aliBalance), transferAmount);
 });
 
-runner.test('Can close empty balance account', async (t, {ft, ali, root}) => {
+runner.test('Can close empty balance account', async (test, {ft, ali, root}) => {
   await init_ft(ft, root);
 
   await registerUser(ft, ali);
@@ -103,15 +103,15 @@ runner.test('Can close empty balance account', async (t, {ft, ali, root}) => {
     {attachedDeposit: '1'},
   ) as boolean;
 
-  t.is(result, true);
+  test.is(result, true);
 });
 
-runner.test('Can force close non-empty balance account', async (t, {ft, root}) => {
+runner.test('Can force close non-empty balance account', async (test, {ft, root}) => {
   await init_ft(ft, root, '100');
   const errorString = await captureError(async () =>
     root.call(ft, 'storage_unregister', {}, {attachedDeposit: '1'}));
 
-  t.regex(errorString, /Can't unregister the account with the positive balance without force/);
+  test.regex(errorString, /Can't unregister the account with the positive balance without force/);
 
   const result = await root.call_raw(
     ft,
@@ -120,12 +120,12 @@ runner.test('Can force close non-empty balance account', async (t, {ft, root}) =
     {attachedDeposit: '1'},
   );
 
-  t.is(result.logs[0],
+  test.is(result.logs[0],
     `Closed @${root.accountId} with 100`,
   );
 });
 
-runner.test('Transfer call with burned amount', async (t, {ft, defi, root}) => {
+runner.test('Transfer call with burned amount', async (test, {ft, defi, root}) => {
   const initialAmount = new BN(10_000);
   const transferAmount = new BN(100);
   const burnAmount = new BN(10);
@@ -152,36 +152,36 @@ runner.test('Transfer call with burned amount', async (t, {ft, defi, root}) => {
     )
     .signAndSend();
 
-  t.true(result.logs.includes(
+  test.true(result.logs.includes(
     `Closed @${root.accountId} with ${
       (initialAmount.sub(transferAmount)).toString()}`,
   ));
 
-  t.is(result.parseResult(), true);
+  test.is(result.parseResult(), true);
 
-  t.true(result.logs.includes(
+  test.true(result.logs.includes(
     'The account of the sender was deleted',
   ));
-  t.true(result.logs.includes(
+  test.true(result.logs.includes(
     `Account @${root.accountId} burned ${burnAmount.toString()}`,
   ));
 
   // Help: this index is diff from sim, we have 10 len when they have 4
   const callbackOutcome = result.receipts_outcomes[5];
 
-  t.is(callbackOutcome.parseResult(), transferAmount.toString());
+  test.is(callbackOutcome.parseResult(), transferAmount.toString());
   const expectedAmount = transferAmount.sub(burnAmount).toString();
 
   const totalSupply: string = await ft.view('ft_total_supply');
-  t.is(totalSupply, expectedAmount);
+  test.is(totalSupply, expectedAmount);
 
   const defiBalance: string = await ft.view('ft_balance_of', {
     account_id: defi,
   });
-  t.is(defiBalance, expectedAmount);
+  test.is(defiBalance, expectedAmount);
 });
 
-runner.test('Transfer call immediate return no refund', async (t, {ft, defi, root}) => {
+runner.test('Transfer call immediate return no refund', async (test, {ft, defi, root}) => {
   const initialAmount = new BN(10_000);
   const transferAmount = new BN(100);
   await init_ft(ft, root, initialAmount);
@@ -207,11 +207,11 @@ runner.test('Transfer call immediate return no refund', async (t, {ft, defi, roo
   const defiBalance: string = await ft.view('ft_balance_of', {
     account_id: defi,
   });
-  t.deepEqual(new BN(rootBalance), initialAmount.sub(transferAmount));
-  t.deepEqual(new BN(defiBalance), transferAmount);
+  test.deepEqual(new BN(rootBalance), initialAmount.sub(transferAmount));
+  test.deepEqual(new BN(defiBalance), transferAmount);
 });
 
-runner.test('Transfer call promise panics for a full refund', async (t, {ft, defi, root}) => {
+runner.test('Transfer call promise panics for a full refund', async (test, {ft, defi, root}) => {
   const initialAmount = new BN(10_000);
   const transferAmount = new BN(100);
   await init_ft(ft, root, initialAmount);
@@ -230,7 +230,7 @@ runner.test('Transfer call promise panics for a full refund', async (t, {ft, def
     },
     {attachedDeposit: '1', gas: '150000000000000'},
   );
-  t.regex(result.promiseErrorMessages.join('\n'), /ParseIntError/);
+  test.regex(result.promiseErrorMessages.join('\n'), /ParseIntError/);
 
   const rootBalance: string = await ft.view('ft_balance_of', {
     account_id: root,
@@ -238,6 +238,6 @@ runner.test('Transfer call promise panics for a full refund', async (t, {ft, def
   const defiBalance: string = await ft.view('ft_balance_of', {
     account_id: defi,
   });
-  t.deepEqual(new BN(rootBalance), initialAmount);
-  t.deepEqual(new BN(defiBalance), new BN(0));
+  test.deepEqual(new BN(rootBalance), initialAmount);
+  test.deepEqual(new BN(defiBalance), new BN(0));
 });

--- a/packages/ava/README.md
+++ b/packages/ava/README.md
@@ -80,7 +80,7 @@ Manual Install
 4. Write tests.
 
    ```ts
-    runner.test("does something", async (t, { alice, contract }) => {
+    runner.test("does something", async (test, { alice, contract }) => {
       await alice.call(contract, "some_update_function", {
         some_string_argument: "cool",
         some_number_argument: 42,
@@ -89,24 +89,24 @@ Manual Install
         account_id: alice,
       });
       // When --verbose option is used this will print neatly underneath the test in the output.
-      t.log(result)
-      t.is(result, "whatever");
+      test.log(result)
+      test.is(result, "whatever");
     });
 
-    runner.test("does something else", async (t, { alice, contract }) => {
+    runner.test("does something else", async (test, { alice, contract }) => {
       const result = await contract.view("some_view_function", {
         account_id: alice,
       });
-      t.is(result, "some default");
+      test.is(result, "some default");
     });
     ```
 
     `runner.test` is added to `near-runner` by `near-runner-ava`, and is shorthand for:
 
     ```ts
-    import test from 'ava';
+    import avaTest from 'ava';
 
-    test('does something', async (t) => {
+    avaTest('does something', async test => {
       await runner.run(async ({…}) => {
         // tests go here
       });


### PR DESCRIPTION
AVA's docs tell people to use `t`, partially because the top-level variable is usually named `test`. But in our context we have no such top-level variable, and we have a lot teach to people who are so new to all of it, so it makes more sense to use a longer variable name.