### PR TITLE
fix: use ipv4 by default

### DIFF
--- a/.github/workflows/tests-sandbox.yml
+++ b/.github/workflows/tests-sandbox.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest]
-        node-version: [14, 16]
+        node-version: [16, 18, 20]
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v2

--- a/packages/js/src/utils.ts
+++ b/packages/js/src/utils.ts
@@ -8,6 +8,10 @@ import bs58 from 'bs58';
 import {Gas, NEAR} from 'near-units';
 import {NamedAccount, KeyPair, ClientConfig, KeyStore, BN} from './types';
 
+// Fix for node > v17
+import { setDefaultResultOrder } from 'dns';
+setDefaultResultOrder('ipv4first');
+
 export const ONE_NEAR = NEAR.parse('1N');
 
 export function toYocto(amount: string): string {


### PR DESCRIPTION
Currently workspaces hangs when using node `v18` because from `v17` onwards node uses `IPV6` by default, which does not correctly resolve `localhost`.

This PR is an attempt to fix it.