### PR TITLE
Bump near-sandbox to 0.0.18

### DIFF
--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -23,7 +23,7 @@
     "fs-extra": "^10.0.0",
     "js-sha256": "^0.9.0",
     "near-api-js": "^v3.0.3",
-    "near-sandbox": "^0.0.17",
+    "near-sandbox": "^0.0.18",
     "near-units": "^0.1.9",
     "node-port-check": "^2.0.1",
     "promisify-child-process": "^4.1.1",


### PR DESCRIPTION
Bumping to 0.0.18 will allow for near-api-js and other dependents to use the JSON-RPC changes from nearcore v1.37.

near-sandbox PR here: https://github.com/near/sandbox/pull/81
Release: https://github.com/near/sandbox/commit/51e421150e4b2bd65bdb2a44e068258a3a8ccb43