### PR TITLE
release: v4.0.0 - bring nearcore 2.0.0 protocol breaking changes

### DIFF
--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "near-workspaces",
-  "version": "3.5.0",
+  "version": "4.0.0",
   "description": "Write tests in TypeScript/JavaScript to run in a controlled NEAR Sandbox local environment.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The main breaking change is the maximum size of transactions which went from 4.2MB down to 1.5MB. It is safer to release it as 4.x series than risking breaking the users code. Overall, 4.0.0 release upgrade should be smooth for 3.x users.